### PR TITLE
Add reveal letter option

### DIFF
--- a/Hangman App/Hangman App/frmHangman.Designer.cs
+++ b/Hangman App/Hangman App/frmHangman.Designer.cs
@@ -36,6 +36,7 @@
             lblHowManyLetters = new Label();
             txtHowManyLetters = new TextBox();
             lblTriesLeft = new Label();
+            btnReveal = new Button();
             tblWord = new TableLayoutPanel();
             txt1 = new TextBox();
             txt2 = new TextBox();
@@ -119,15 +120,17 @@
             // tblToolbar
             // 
             tblToolbar.AutoSize = true;
-            tblToolbar.ColumnCount = 4;
-            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 30.3039455F));
-            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 30.30395F));
-            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 9.091186F));
-            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 30.3009224F));
+            tblToolbar.ColumnCount = 5;
+            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 10F));
+            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25F));
+            tblToolbar.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25F));
             tblToolbar.Controls.Add(btnStart, 0, 0);
             tblToolbar.Controls.Add(lblHowManyLetters, 1, 0);
             tblToolbar.Controls.Add(txtHowManyLetters, 2, 0);
             tblToolbar.Controls.Add(lblTriesLeft, 3, 0);
+            tblToolbar.Controls.Add(btnReveal, 4, 0);
             tblToolbar.Dock = DockStyle.Fill;
             tblToolbar.Location = new Point(3, 3);
             tblToolbar.Name = "tblToolbar";
@@ -180,8 +183,19 @@
             lblTriesLeft.Text = " ";
             lblTriesLeft.TextAlign = ContentAlignment.MiddleCenter;
             // 
+            // btnReveal
+            //
+            btnReveal.Dock = DockStyle.Fill;
+            btnReveal.Font = new Font("Segoe UI", 11F);
+            btnReveal.Location = new Point(0, 0);
+            btnReveal.Name = "btnReveal";
+            btnReveal.Size = new Size(127, 46);
+            btnReveal.TabIndex = 4;
+            btnReveal.Text = "Reveal";
+            btnReveal.UseVisualStyleBackColor = true;
+            //
             // tblWord
-            // 
+            //
             tblWord.ColumnCount = 9;
             tblWord.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 11.11111F));
             tblWord.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 11.1111107F));
@@ -727,6 +741,7 @@
         private Label lblHowManyLetters;
         private TextBox txtHowManyLetters;
         private Label lblTriesLeft;
+        private Button btnReveal;
         private TableLayoutPanel tblWord;
         private TextBox txt1;
         private TextBox txt2;

--- a/Hangman App/Hangman App/frmHangman.cs
+++ b/Hangman App/Hangman App/frmHangman.cs
@@ -23,6 +23,8 @@ namespace Hangman_App
             lstletterbtn.ForEach(b => b.Click += LetterBtn_Click);
 
             btnStart.Click += BtnStart_Click;
+            btnReveal.Click += BtnReveal_Click;
+            btnReveal.Enabled = false;
         }
 
         private void ClearScreen()
@@ -36,6 +38,7 @@ namespace Hangman_App
             picturenumber = 14;
             lstletterbtn.ForEach(b => b.Enabled = false);
             lblTriesLeft.Text = "";
+            btnReveal.Enabled = false;
             GetNextPicture();
         }
 
@@ -61,6 +64,7 @@ namespace Hangman_App
                 return;
             }
             lstletterbtn.ForEach(b => b.Enabled = true);
+            btnReveal.Enabled = true;
             numoftries = 12;
             lblTriesLeft.Text = numoftries.ToString() + " Tries Left";
             chosenword = lstwords.Where(w => w.Length == amntofletters).Random().ToLower();
@@ -128,6 +132,31 @@ namespace Hangman_App
             btnletter.Enabled = false;
             CheckWordIfLetter(btnletter);
 
+        }
+
+        private void BtnReveal_Click(object? sender, EventArgs e)
+        {
+            var hidden = lstchosenword
+                .Select((t, i) => new { TextBox = t, Index = i })
+                .Where(x => x.TextBox.Text == "")
+                .ToList();
+            if (hidden.Count == 0)
+            {
+                return;
+            }
+            Random rnd = new();
+            var reveal = hidden[rnd.Next(hidden.Count)].Index;
+            char letter = chosenword[reveal];
+            lstchosenword[reveal].Text = letter.ToString();
+            var btn = lstletterbtn.FirstOrDefault(b => b.Text.Equals(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+            if (btn != null)
+            {
+                btn.Enabled = false;
+            }
+            numoftries--;
+            lblTriesLeft.Text = numoftries.ToString() + " Tries Left";
+            GetNextPicture();
+            CheckForWin();
         }
     }
 }

--- a/Hangman App/Hangman App/frmHangman.cs
+++ b/Hangman App/Hangman App/frmHangman.cs
@@ -12,6 +12,7 @@ namespace Hangman_App
         string chosenword;
         int picturenumber = 14;
         int numoftries = 12;
+        int revealsUsed = 0;
 
         public frmHangman()
         {
@@ -39,6 +40,7 @@ namespace Hangman_App
             lstletterbtn.ForEach(b => b.Enabled = false);
             lblTriesLeft.Text = "";
             btnReveal.Enabled = false;
+            revealsUsed = 0;
             GetNextPicture();
         }
 
@@ -65,6 +67,7 @@ namespace Hangman_App
             }
             lstletterbtn.ForEach(b => b.Enabled = true);
             btnReveal.Enabled = true;
+            revealsUsed = 0;
             numoftries = 12;
             lblTriesLeft.Text = numoftries.ToString() + " Tries Left";
             chosenword = lstwords.Where(w => w.Length == amntofletters).Random().ToLower();
@@ -136,6 +139,11 @@ namespace Hangman_App
 
         private void BtnReveal_Click(object? sender, EventArgs e)
         {
+            if (revealsUsed >= 3)
+            {
+                btnReveal.Enabled = false;
+                return;
+            }
             var hidden = lstchosenword
                 .Select((t, i) => new { TextBox = t, Index = i })
                 .Where(x => x.TextBox.Text == "")
@@ -157,6 +165,11 @@ namespace Hangman_App
             lblTriesLeft.Text = numoftries.ToString() + " Tries Left";
             GetNextPicture();
             CheckForWin();
+            revealsUsed++;
+            if (revealsUsed >= 3)
+            {
+                btnReveal.Enabled = false;
+            }
         }
     }
 }

--- a/Hangman App/Hangman App/frmHangman.cs
+++ b/Hangman App/Hangman App/frmHangman.cs
@@ -153,9 +153,15 @@ namespace Hangman_App
                 return;
             }
             Random rnd = new();
-            var reveal = hidden[rnd.Next(hidden.Count)].Index;
-            char letter = chosenword[reveal];
-            lstchosenword[reveal].Text = letter.ToString();
+            var revealIndex = hidden[rnd.Next(hidden.Count)].Index;
+            char letter = chosenword[revealIndex];
+            for (int i = 0; i < chosenword.Length; i++)
+            {
+                if (chosenword[i] == letter && lstchosenword[i].Text == "")
+                {
+                    lstchosenword[i].Text = letter.ToString();
+                }
+            }
             var btn = lstletterbtn.FirstOrDefault(b => b.Text.Equals(letter.ToString(), StringComparison.OrdinalIgnoreCase));
             if (btn != null)
             {


### PR DESCRIPTION
## Summary
- extend toolbar layout to include a *Reveal* button
- allow players to reveal a random hidden letter at the cost of one try
- enable the new button only during an active game

## Testing
- `dotnet build 'Hangman App/Hangman App/Hangman App.csproj' -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68630573c4b0832da3036d79b54ca995